### PR TITLE
support for angular universal prerender

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bfoese/ngx-preload-fonts",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bfoese/ngx-preload-fonts",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "chalk": "^4.1.0",
         "commander": "^5.1.0",
@@ -28,6 +28,7 @@
         "husky": "^6.0.0",
         "istanbul-badges-readme": "^1.2.1",
         "jest": "^26.6.3",
+        "mock-fs": "^5.1.4",
         "prettier": "^2.1.2",
         "rimraf": "^3.0.2",
         "standard-version": "^9.2.0",
@@ -7060,6 +7061,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mock-fs": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.4.tgz",
+      "integrity": "sha512-sudhLjCjX37qWIcAlIv1OnAxB2wI4EmXByVuUjILh1rKGNGpGU8GNnzw+EAbrhdpBe0TL/KONbK1y3RXZk8SxQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/modify-values": {
@@ -16088,6 +16098,12 @@
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
       }
+    },
+    "mock-fs": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.1.4.tgz",
+      "integrity": "sha512-sudhLjCjX37qWIcAlIv1OnAxB2wI4EmXByVuUjILh1rKGNGpGU8GNnzw+EAbrhdpBe0TL/KONbK1y3RXZk8SxQ==",
+      "dev": true
     },
     "modify-values": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "husky": "^6.0.0",
     "istanbul-badges-readme": "^1.2.1",
     "jest": "^26.6.3",
+    "mock-fs": "^5.1.4",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",
     "standard-version": "^9.2.0",

--- a/src/file.util.ts
+++ b/src/file.util.ts
@@ -84,6 +84,31 @@ export class FileUtil {
     return match && match.length > 0 ? file.substr(0, file.indexOf(match[0])) : undefined;
   }
 
+  /**
+   *
+   * @param root - base directory from where the search starts
+   * @param indexFile - file name including fingerprint
+   * @returns Array of paths containing base files to be optimized
+   */
+  public static findRecursivePrerenderedDirs(root: string, indexFile: string): string[] {
+    const appPrerenderedDirs = [];
+
+    const dirs = fs.readdirSync(root).filter((item) => fs.statSync(`${root}/${item}`).isDirectory());
+    if (dirs) {
+      for (const dir of dirs) {
+        if (FileUtil.containsIndexFile(`${root}/${dir}`, indexFile)) {
+          appPrerenderedDirs.push(`${root}/${dir}`);
+        }
+        const subDirs = FileUtil.findRecursivePrerenderedDirs(`${root}/${dir}`, indexFile);
+        if (subDirs) {
+          appPrerenderedDirs.push(...subDirs);
+        }
+      }
+    }
+
+    return appPrerenderedDirs;
+  }
+
   public static filterFonts(
     files: string[],
     include: string[] | undefined,


### PR DESCRIPTION
I have added support for a deep scan on every base directory, looking for the injection marker.

Enabled the toggle:
```
  -p, --prerender-scan     Search for index files deep into the base directory, so every injection marker will be replaced (Angular Universal Prerender compatibility). (default: false)
```

I have written a small unit test, assing a new devDependency: [mock-fs](https://www.npmjs.com/package/mock-fs).
